### PR TITLE
Fix #7 - don't ignore errors from pread(2)

### DIFF
--- a/src/libbloom/bitmap.c
+++ b/src/libbloom/bitmap.c
@@ -120,7 +120,8 @@ int bitmap_from_file(int fileno, uint64_t len, bitmap_mode mode, bloom_bitmap *m
  * Populates a buffer with the contents of a file
  */
 static int fill_buffer(int fileno, unsigned char* buf, uint64_t len) {
-    uint64_t total_read = 0, more;
+    uint64_t total_read = 0;
+    ssize_t more;
     while (total_read < len) {
         more = pread(fileno, buf+total_read, len-total_read, total_read);
         if (more == 0)


### PR DESCRIPTION
Use a signed type for result from pread(2), so the error handling case
actually trips. Good thing pread(2) should basically never error for
local files =).

CR: gcc, tests (with py.test 2.2.4, if it matters)
