### PR TITLE
Fix #6: Generate random hashmap seed at process start

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -27,7 +27,7 @@ objs =  envbloomd_with_err.Object('src/bloomd/config', 'src/bloomd/config.c') + 
         envbloomd_with_err.Object('src/bloomd/filter_manager', 'src/bloomd/filter_manager.c') + \
         envbloomd_with_err.Object('src/bloomd/background', 'src/bloomd/background.c')
 
-bloom_libs = ["pthread", murmur, bloom, inih, spooky, "m"]
+bloom_libs = ["pthread", murmur, bloom, inih, spooky, "m", "crypto"]
 if platform.system() == 'Linux':
    bloom_libs.append("rt")
 

--- a/src/bloomd/bloomd.c
+++ b/src/bloomd/bloomd.c
@@ -15,6 +15,7 @@
 #include <syslog.h>
 #include <unistd.h>
 #include <signal.h>
+#include <openssl/err.h>
 #include "config.h"
 #include "hashmap.h"
 #include "networking.h"
@@ -115,6 +116,9 @@ int main(int argc, char **argv) {
     // Initialize syslog
     setup_syslog();
 
+    // Load OpenSSL error strings
+    ERR_load_crypto_strings();
+
     // Parse the command line
     char *config_file = NULL;
     int workers = 0;
@@ -144,12 +148,6 @@ int main(int argc, char **argv) {
 
     // Log that we are starting up
     syslog(LOG_INFO, "Starting bloomd.");
-
-    int hm_res = init_hashmap_random();
-    if (hm_res != 0) {
-        syslog(LOG_ERR, "Failed to initialize hashmap!");
-        return 1;
-    }
 
     // Initialize the filters
     bloom_filtmgr *mgr;

--- a/src/bloomd/hashmap.c
+++ b/src/bloomd/hashmap.c
@@ -2,13 +2,14 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <syslog.h>
 #include <unistd.h>
+#include <openssl/err.h>
+#include <openssl/rand.h>
 #include "hashmap.h"
 
 #define MAX_CAPACITY 0.75
 #define DEFAULT_CAPACITY 128
-
-static uint32_t mh3_seed;
 
 // Basic hash entry.
 typedef struct hashmap_entry {
@@ -21,6 +22,7 @@ struct bloom_hashmap {
     int count;      // Number of entries
     int table_size; // Size of table in nodes
     int max_size;   // Max size before we resize
+    uint32_t seed;  // Random hash seed
     hashmap_entry *table; // Pointer to an arry of hashmap_entry objects
 };
 
@@ -28,25 +30,25 @@ struct bloom_hashmap {
 extern void MurmurHash3_x64_128(const void * key, const int len, const uint32_t seed, void *out);
 
 /**
- * Load hash seed value from system randomness source.
- * @return 0 on success, -1 on error (setting errno)
+ * Create hash seed value from good randomness source.
+ * @arg random The output random value
+ * @return 0 on success, -1 on error
  */
-int init_hashmap_random(void) {
-    int fd, rc = -1;
-    ssize_t rd;
+static int hashmap_get_random(uint32_t *random_out) {
+    unsigned long ssl_err;
+    int rc;
 
-    fd = open("/dev/random", O_RDONLY);
-    if (fd < 0)
-        goto out;
+    rc = RAND_bytes((void*)random_out, sizeof *random_out);
+    if (rc == 1)
+        return 0;
 
-    rd = read(fd, &mh3_seed, sizeof mh3_seed);
-    if (rd < sizeof mh3_seed)
-        goto out;
+    char errbuf[200];
 
-    rc = close(fd);
+    ssl_err = ERR_get_error();
+    ERR_error_string_n(ssl_err, errbuf, sizeof errbuf);
 
-out:
-    return rc;
+    syslog(LOG_ERR, "%s failed! %s", __func__, errbuf);
+    return -1;
 }
 
 /**
@@ -56,6 +58,9 @@ out:
  * @return 0 on success.
  */
 int hashmap_init(int initial_size, bloom_hashmap **map) {
+    int rc;
+    uint32_t random_seed;
+
     // Default to 64 if no size
     if (initial_size <= DEFAULT_CAPACITY) {
        initial_size = DEFAULT_CAPACITY;
@@ -75,10 +80,16 @@ int hashmap_init(int initial_size, bloom_hashmap **map) {
         initial_size = 1 << most_sig_bit;
     }
 
+    // Get a random seed to protect table against DoS collision attacks
+    rc = hashmap_get_random(&random_seed);
+    if (rc < 0)
+        return -1;
+
     // Allocate the map
     bloom_hashmap *m = calloc(1, sizeof(bloom_hashmap));
     m->table_size = initial_size;
     m->max_size = MAX_CAPACITY * initial_size;
+    m->seed = random_seed;
 
     // Allocate the table
     m->table = (hashmap_entry*)calloc(initial_size, sizeof(hashmap_entry));
@@ -139,7 +150,7 @@ int hashmap_size(bloom_hashmap *map) {
 int hashmap_get(bloom_hashmap *map, char *key, void **value) {
     // Compute the hash value of the key
     uint64_t out[2];
-    MurmurHash3_x64_128(key, strlen(key), mh3_seed, &out);
+    MurmurHash3_x64_128(key, strlen(key), map->seed, &out);
 
     // Mod the lower 64bits of the hash function with the table
     // size to get the index
@@ -176,10 +187,10 @@ int hashmap_get(bloom_hashmap *map, char *key, void **value) {
  * @return 1 if the key is new, 0 if updated.
  */
 static int hashmap_insert_table(hashmap_entry *table, int table_size, char *key, int key_len,
-                                void *value, int should_cmp, int should_dup) {
+                                void *value, int should_cmp, int should_dup, uint32_t seed) {
     // Compute the hash value of the key
     uint64_t out[2];
-    MurmurHash3_x64_128(key, key_len, mh3_seed, &out);
+    MurmurHash3_x64_128(key, key_len, seed, &out);
 
     // Mod the lower 64bits of the hash function with the table
     // size to get the index
@@ -246,7 +257,7 @@ static void hashmap_double_size(bloom_hashmap *map) {
             // Do not compare keys or duplicate since we are just doubling our
             // size, and we have unique keys and duplicates already.
             hashmap_insert_table(new_table, new_size, old->key, strlen(old->key),
-                    old->value, 0, 0);
+                    old->value, 0, 0, map->seed);
 
             // The initial entry is in the table
             // and we should not free that one.
@@ -284,7 +295,8 @@ int hashmap_put(bloom_hashmap *map, char *key, void *value) {
     }
 
     // Insert into the map, comparing keys and duplicating keys
-    int new = hashmap_insert_table(map->table, map->table_size, key, strlen(key), value, 1, 1);
+    int new = hashmap_insert_table(map->table, map->table_size, key,
+        strlen(key), value, 1, 1, map->seed);
     if (new) map->count += 1;
 
     return new;
@@ -299,7 +311,7 @@ int hashmap_put(bloom_hashmap *map, char *key, void *value) {
 int hashmap_delete(bloom_hashmap *map, char *key) {
     // Compute the hash value of the key
     uint64_t out[2];
-    MurmurHash3_x64_128(key, strlen(key), mh3_seed, &out);
+    MurmurHash3_x64_128(key, strlen(key), map->seed, &out);
 
     // Mod the lower 64bits of the hash function with the table
     // size to get the index

--- a/src/bloomd/hashmap.h
+++ b/src/bloomd/hashmap.h
@@ -8,12 +8,6 @@ typedef struct bloom_hashmap bloom_hashmap;
 typedef int(*hashmap_callback)(void *data, const char *key, void *value);
 
 /**
- * Load hash seed value from system randomness source.
- * @return 0 on success.
- */
-int init_hashmap_random(void);
-
-/**
  * Creates a new hashmap and allocates space for it.
  * @arg initial_size The minimim initial size. 0 for default (64).
  * @arg map Output. Set to the address of the map


### PR DESCRIPTION
- Add init_hashmap_random() to hashmap API
- Fix users of MurmerHash3 in hashmap.c to use new seed value
- Call init_hashmap_random() in early startup in bloomd.c

CR: gcc, tests
