### PR TITLE
Fix #5 - Style nit, 'const' for int param

### DIFF
--- a/deps/murmurhash/MurmurHash3.cpp
+++ b/deps/murmurhash/MurmurHash3.cpp
@@ -253,7 +253,7 @@ extern "C" void MurmurHash3_x86_128 ( const void * key, const int len,
 //-----------------------------------------------------------------------------
 
 extern "C" void MurmurHash3_x64_128 ( const void * key, const int len,
-                           const uint32_t seed, void * out )
+                           uint32_t seed, void * out )
 {
   const uint8_t * data = (const uint8_t*)key;
   const int nblocks = len / 16;


### PR DESCRIPTION
For some reason, MurmurHash3_x64_128() has 'const' in front of 'seed',
which is an integer type. This doesn't seem like it will yield any
compiler optimizations at all, especially given that we are NOT inlining
the MurmurHash functions. Additionally, this doesn't match any of the
other hash functions, nor the header's prototype of the function. So
just drop the 'const'.

CR: gcc, tests
