### PR TITLE
Fix dirty page handling again, follow-up to af0a1c46

### DIFF
--- a/src/libbloom/bitmap.h
+++ b/src/libbloom/bitmap.h
@@ -85,10 +85,10 @@ inline void bitmap_setbit(bloom_bitmap *map, uint64_t idx) {
     if (map->mode == PERSISTENT) {
         // >> 12 for 4096 (bytes/page), >> 3 for 8 (bits/byte)
         uint64_t page = idx >> 15;
-        byte = map->dirty_pages[page >> 3];
+        byte = map->dirty_pages[page];
         byte_off = 7 - page % 8;
         byte |= 1 << byte_off;
-        map->dirty_pages[page >> 3] = byte;
+        map->dirty_pages[page] = byte;
     }
 }
 


### PR DESCRIPTION
Changeset af0a1c46 fixes dirty pages setting the actual correct bit
but in doing so it now updates the wrong byte.

For a page size of 4096 and 8bits per char, the byte updated is off
by a factor of 1/8, caused by right-shifting by 3 twice.
