### PR TITLE
Add some notes about the value of `capacity` and `prob`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ For the ``create`` command, the format is:
 
     create filter_name [capacity=initial_capacity] [prob=max_prob] [in_memory=0|1]
 
+Note:
+1. `capacity` must > 10,000 (1e4, 10K)
+2. `capacity` is suggested <= 1,000,000,000 (1e9, 1G)
+3. `prob` must < 0.1 (1e-1)
+4. `prob` is suggested <= 0.01 (1e-2)
+
 Where ``filter_name`` is the name of the filter,
 and can contain the characters a-z, A-Z, 0-9, ., _.
 If an initial capacity is provided the filter

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ For the ``create`` command, the format is:
     create filter_name [capacity=initial_capacity] [prob=max_prob] [in_memory=0|1]
 
 Note:
+
 1. `capacity` must > 10,000 (1e4, 10K)
 2. `capacity` is suggested <= 1,000,000,000 (1e9, 1G)
 3. `prob` must < 0.1 (1e-1)

--- a/src/bloomd/config.c
+++ b/src/bloomd/config.c
@@ -273,7 +273,7 @@ int sane_default_probability(double prob) {
         syslog(LOG_ERR,
                "Probability cannot be equal-to or greater than 1!");
         return 1;
-    } else if (prob >= 0.10) {
+    } else if (prob >= 0.10) {  // prob must < 0.10
         syslog(LOG_ERR, "Default probability too high!");
         return 1;
     } else if (prob > 0.01) {

--- a/src/bloomd/config.c
+++ b/src/bloomd/config.c
@@ -258,11 +258,11 @@ int sane_log_level(char *log_level, int *syslog_level) {
 }
 
 int sane_initial_capacity(int64_t initial_capacity) {
-    if (initial_capacity <= 10000) {
+    if (initial_capacity <= 10000) {  // 1e4, 10K
         syslog(LOG_ERR,
                "Initial capacity cannot be less than 10K!");
         return 1;
-    } else if (initial_capacity > 1000000000) {
+    } else if (initial_capacity > 1000000000) {  // 1e9, 1G
         syslog(LOG_WARNING, "Initial capacity set very high!");
     }
     return 0;


### PR DESCRIPTION
Hi, 
Thank you for your contributions on this awesome **bloomd**
When I used the `bloomd` for some test, I noticed that I could not set the value of `capacity` and `prob` as I wanted.
So I read the source code and figured out the reason.
I think it's necessay to let users know the limits about the value. There for, I add some notes in the Readme file.

BTW, I am glad to send my first pull request to bloomd.
Thank you again.
