### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.*
+integ/
+tests/
+bench.c
+*.mdown
+*.md
+LICENSE
+Vagrantfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+############
+# BUILDER - Used to build the bloomd binary
+############
+
+FROM alpine:3.10.2 as BUILDER
+
+WORKDIR /etc/bloomd
+
+RUN apk add --no-cache build-base gcc py-pip
+
+RUN pip install SCons
+
+COPY deps deps
+
+RUN cd deps/check-0.9.8 && ./configure && make && make install
+
+RUN cd /etc/bloomd
+
+COPY src src
+COPY SConstruct SConstruct
+
+RUN scons
+
+
+############
+# RUNNER - Use Bloomd binary generated in the builder above
+############
+
+FROM alpine:3.10.2 as RUNNER
+
+WORKDIR /etc/bloomd
+RUN mkdir /data
+
+ENV BLOOMD_PORT=8673
+ENV BLOOMD_LOG_LEVEL=INFO
+ENV BLOOMD_DATA_DIR=/data
+ENV BLOOMD_FLUSH_INTERVAL=300
+ENV BLOOMD_WORKERS=2
+
+COPY --from=BUILDER /etc/bloomd/bloomd /etc/bloomd/bloomd
+
+RUN printf "#!/bin/sh\n\
+printf \"[bloomd]\\ntcp_port = \$BLOOMD_PORT\\ndata_dir = \$BLOOMD_DATA_DIR\\nlog_level = \$BLOOMD_LOG_LEVEL\\nflush_interval = \$BLOOMD_FLUSH_INTERVAL\\nworkers = \$BLOOMD_WORKERS\" > /etc/bloomd/bloomd.conf \n \
+./bloomd -f /etc/bloomd/bloomd.conf" > entry.sh
+
+RUN chmod +x entry.sh
+
+CMD ["./entry.sh"]


### PR DESCRIPTION
Dockerfile used to create a container for bloomd (running on Alpine)

Some configuration options can be set using env variables:

| Name | Default value | Description |
|------|---------------|-------------|
|   BLOOMD_PORT   |       `8673`        |      Port used to listen to incoming connections       |
|  BLOOMD_LOG_LEVEL    |      `INFO`         |      Log level       |
|   BLOOMD_DATA_DIR   |      `/data`         |     Folder used to store bloomd databases        |
|   BLOOMD_FLUSH_INTERVAL   |       `300`        |       Flush interval to write changes to disk      |
|   BLOOMD_WORKERS   |       `2`        |       Number of workers      |

Build:
```bash
docker build -t armon/bloomd:latest .
```

On this PR, you will encounter this error when building: https://github.com/armon/bloomd/issues/54

Run:
```
docker run -it --rm -p 8673:8673 armon/bloomd:latest
```

With shared folder:
```
docker run -it --rm -p 8673:8673 -v `pwd`/datafolder:/data armon/bloomd:latest
```


Image size: `5.71MB`