### PR TITLE
Fixes #58 - Build errors (cc1: all warnings being treated as errors)

### DIFF
--- a/src/bloomd/bloomd.c
+++ b/src/bloomd/bloomd.c
@@ -25,7 +25,7 @@ typedef struct {
     bloom_filtmgr *mgr;
     bloom_networking *netconf;
 } worker_args;
-static void worker_main(worker_args *args);
+static void *worker_main(worker_args *args);
 
 /**
  * By default we should run. Our signal
@@ -208,11 +208,13 @@ int main(int argc, char **argv) {
 }
 
 // Main entry point for the worker threads
-static void worker_main(worker_args *args) {
+static void *worker_main(worker_args *args) {
     // Perform the initial checkpoint with the manager
     filtmgr_client_checkpoint(args->mgr);
 
     // Enter the networking event loop forever
     start_networking_worker(args->netconf);
+
+    return NULL;
 }
 

--- a/src/bloomd/conn_handler.c
+++ b/src/bloomd/conn_handler.c
@@ -64,6 +64,7 @@ int handle_client_connect(bloom_conn_handler *handle) {
     char *buf, *arg_buf;
     int buf_len, arg_buf_len, should_free;
     int status;
+    arg_buf_len = 0;
     while (1) {
         status = extract_to_terminator(handle->conn, '\n', &buf, &buf_len, &should_free);
         if (status == -1) break; // Return if no command is available


### PR DESCRIPTION
Closes Issue #58 

Build errors when warnings are treated as errors (default build settings).